### PR TITLE
Crash on exporting long audio as "audio data"

### DIFF
--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -58,6 +58,7 @@
 #include "widgets/LabelCounterInputDialog.h"
 #include "widgets/ActivityLog.h"
 #include "widgets/UnitConverter.h"
+#include "widgets/ProgressDialog.h"
 #include "audio/AudioCallbackPlaySource.h"
 #include "audio/AudioCallbackRecordTarget.h"
 #include "audio/PlaySpeedRangeMapper.h"
@@ -2726,7 +2727,15 @@ MainWindow::exportAudio(bool asData)
 
     if (!multiple) {
         if (asData) {
-            CSVFileWriter writer(path, model,
+            stop();
+            ProgressDialog dialog {
+                QObject::tr("Exporting audio data..."),
+                true,
+                0,
+                this,
+                Qt::ApplicationModal
+            };
+             CSVFileWriter writer(path, model, &dialog,
                                  ((QFileInfo(path).suffix() == "csv") ?
                                   "," : "\t"));
             if (selectionToWrite) {

--- a/vext-lock.json
+++ b/vext-lock.json
@@ -4,7 +4,7 @@
       "pin": "a87e1bcce7b0"
     },
     "svcore": {
-      "pin": "6311c5e54f0ae3bec14a8a40e35b7c05340543fc"
+      "pin": "f28d1bf04b1b5fca07661a68001382e81a959de3"
     },
     "svgui": {
       "pin": "e7bf3275708ac234446a4afbe92342521e8e2945"

--- a/vext-lock.json
+++ b/vext-lock.json
@@ -4,10 +4,10 @@
       "pin": "a87e1bcce7b0"
     },
     "svcore": {
-      "pin": "bd73a689c8af"
+      "pin": "6311c5e54f0ae3bec14a8a40e35b7c05340543fc"
     },
     "svgui": {
-      "pin": "a9c2e791ab8d"
+      "pin": "e7bf3275708ac234446a4afbe92342521e8e2945"
     },
     "svapp": {
       "pin": "72b4870f0e6b"

--- a/vext-project.json
+++ b/vext-project.json
@@ -15,12 +15,18 @@
             "service": "soundsoftware"
         },
         "svcore": {
-            "vcs": "hg",
-	    "service": "soundsoftware"
+            "vcs": "git",
+            "service": "github",
+            "owner": "LucasThompson",
+            "repository": "svcore",
+            "branch": "dev/streaming-csv-writer"
         },
         "svgui": {
-            "vcs": "hg",
-	    "service": "soundsoftware"
+            "vcs": "git",
+            "service": "github",
+            "owner": "LucasThompson",
+            "repository": "svgui",
+            "branch": "dev/modal-progress-dialog"
         },
         "svapp": {
             "vcs": "hg",


### PR DESCRIPTION
This pulls in the changes from sonic-visualiser/svcore#3 and sonic-visualiser/svgui#1, keeping the exporting on the GUI thread allowed for minimal code change, although the exporting is quite slow.