### PR TITLE
Provide NSMicrophoneUsageDescription to force audio permission dialog

### DIFF
--- a/deploy/osx/Info.plist
+++ b/deploy/osx/Info.plist
@@ -21,6 +21,10 @@
 	<key>NSHighResolutionCapable</key>
 	<string>True</string>
 
+	<!-- enable microphone access -->
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Sonic Visualiser requires microphone access to enable recording functionality.</string>
+
 	<key>CFBundleDocumentTypes</key>
 
 	<array>


### PR DESCRIPTION
Appears to fix #4.

I must say I don't know much about this, and I don't fully understand it.

First of all, are you able to replicate this?

It is the same for me with Tony, and some other applications. (I was actually trying out some [Cinder](https://www.libcinder.org) sample projects, which no longer work. This caused me to remember that Mojave introduced some more entitlement / permissions stuff, so checked other open source apps on my system e.g. SV / Tony / Audacity).

Audacity appears to work, and prompts for microphone access. There appears to be nothing special in their plist. I also had an old dev build of SV on my system, and strangely that did prompt me.

The presence of the `NSMicrophoneUsageDescription` key in the plist appears to force the permissions dialog, at least for me.

Let me know what you find. It might be sensible to provide a message regardless, let me know if you have preferred wording. 