### PR TITLE
Exclude repository configurations from archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.git*      	export-ignore
+.travis.yml	export-ignore
+.appveyor.yml	export-ignore


### PR DESCRIPTION
There is little use in having repository configuration files (`.gitignore`, `.hgignore` (wtf?), or even CI-configurations) included in the "Source download" tarballs (which are generated by `git archive`).

This PR excludes such files from the so generated tarballs.

People who do want these configurations, will probably do a `git clone` anyhow (which will continue to work as is)

In reality i'm more interested in excluding these files from the *manually* created tarballs (e.g. [this one](https://github.com/sonic-visualiser/sonic-visualiser/releases/download/sv_v4.4/sonic-visualiser-4.4.tar.gz)), but I don't really understand how you do generate them, so this PR is a first start.